### PR TITLE
SECURITY-1421 Explicitly set AuthenticationMethods

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -15,6 +15,7 @@ profile_hostbased_ssh::source::host_match_custom_config:
   UserKnownHostsFile: "/dev/null"
 
 profile_hostbased_ssh::target::sshd_custom_config:
+  AuthenticationMethods: "hostbased"
   GSSAPIAuthentication: "no"
   HostbasedAuthentication: "yes"
   KerberosAuthentication: "no"


### PR DESCRIPTION
Explicitly set AuthenticationMethods in the match block so that we can eventually set
AuthenticationMethods None
in the global config