### PR TITLE
SECURITY-1459: update PAM config after authselect runs

### DIFF
--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -25,10 +25,12 @@ profile_hostbased_ssh::pam_slurm_adopt::pam_config:
     module: "pam_systemd.so"
     service: "password-auth"
     type: "session"
+    require: "Class[Pam_access::Pam::Redhat]"
   'remove pam_systemd.so from system-auth':
     ensure: "absent"
     module: "pam_systemd.so"
     service: "system-auth"
     type: "session"
+    require: "Class[Pam_access::Pam::Redhat]"
 profile_hostbased_ssh::pam_slurm_adopt::services_to_mask:
   - "systemd-logind.service"


### PR DESCRIPTION
For Red Hat machines, make PAM config changes happen
after pam_access::pam::redhat class is processed.