### PR TITLE
SVCPLAN-5555: update references to pam_access classes

### DIFF
--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -25,12 +25,12 @@ profile_hostbased_ssh::pam_slurm_adopt::pam_config:
     module: "pam_systemd.so"
     service: "password-auth"
     type: "session"
-    require: "Class[Pam_access::Pam::Redhat]"
+    require: "Class[Pam_access::Pam::Authselect]"
   'remove pam_systemd.so from system-auth':
     ensure: "absent"
     module: "pam_systemd.so"
     service: "system-auth"
     type: "session"
-    require: "Class[Pam_access::Pam::Redhat]"
+    require: "Class[Pam_access::Pam::Authselect]"
 profile_hostbased_ssh::pam_slurm_adopt::services_to_mask:
   - "systemd-logind.service"


### PR DESCRIPTION
ncsa/pam_access version ncsa/1.1.1 has a change in class name.

profile_hostbased_ssh is updated in this commit with require references to suit:
Class[Pam_access::Pam::Redhat]
->
Class[Pam_access::Pam::Authselect]