### PR TITLE
SVCPLAN-5586: Make management of ssh_known_hosts and shosts.equiv opt…

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -48,6 +48,7 @@ Hash of the form:
     hosts:
       ...
   ...
+Leave set to {} to NOT manage shosts.equiv and ssh_known_hosts.
 
 ##### <a name="-profile_hostbased_ssh--known_hosts--ssh_known_hosts_file"></a>`ssh_known_hosts_file`
 
@@ -78,11 +79,12 @@ include profile_hostbased_ssh::pam_slurm_adopt
 
 The following parameters are available in the `profile_hostbased_ssh::pam_slurm_adopt` class:
 
-* [`pam_configs`](#-profile_hostbased_ssh--pam_slurm_adopt--pam_configs)
-* [`services_to_mask`](#-profile_hostbased_ssh--pam_slurm_adopt--services_to_mask)
 * [`pam_config`](#-profile_hostbased_ssh--pam_slurm_adopt--pam_config)
+* [`services_to_mask`](#-profile_hostbased_ssh--pam_slurm_adopt--services_to_mask)
 
-##### <a name="-profile_hostbased_ssh--pam_slurm_adopt--pam_configs"></a>`pam_configs`
+##### <a name="-profile_hostbased_ssh--pam_slurm_adopt--pam_config"></a>`pam_config`
+
+Data type: `Hash`
 
 Hash of data to pass to augeasproviders_pam.
 
@@ -91,12 +93,6 @@ Hash of data to pass to augeasproviders_pam.
 Data type: `Array`
 
 Array of services to stop and mask
-
-##### <a name="-profile_hostbased_ssh--pam_slurm_adopt--pam_config"></a>`pam_config`
-
-Data type: `Hash`
-
-
 
 ### <a name="profile_hostbased_ssh--shosts_equiv"></a>`profile_hostbased_ssh::shosts_equiv`
 
@@ -122,7 +118,7 @@ The following parameters are available in the `profile_hostbased_ssh::shosts_equ
 
 Data type: `String`
 
-
+Path to shosts.equiv file.
 
 ### <a name="profile_hostbased_ssh--source"></a>`profile_hostbased_ssh::source`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,5 +1,6 @@
 ---
 
+profile_hostbased_ssh::known_hosts::hosts_data: {}
 profile_hostbased_ssh::known_hosts::ssh_known_hosts_file: "/etc/ssh/ssh_known_hosts"
 
 profile_hostbased_ssh::shosts_equiv::shosts_equiv_file: "/etc/ssh/shosts.equiv"

--- a/data/os/Suse.yaml
+++ b/data/os/Suse.yaml
@@ -1,0 +1,37 @@
+---
+
+profile_hostbased_ssh::pam_slurm_adopt::pam_config:
+# exempt root from pam_slurm_adopt
+  'add account pam_succeed_if.so for privileged accounts to sshd':
+    arguments: ["uid", "=", "0"]
+    control: "sufficient"
+    ensure: "present"
+    module: "pam_succeed_if.so"
+    position: "after *[type=\"account\" and module=\"common-account\"]"
+    service: "sshd"
+    type: "account"
+# exempt other local users from pam_slurm_adopt
+  'add account pam_localuser.so for local accounts to sshd':
+    control: "sufficient"
+    ensure: "present"
+    module: "pam_localuser.so"
+    position: "after *[type=\"account\" and module=\"pam_succeed_if.so\"]"
+    service: "sshd"
+    type: "account"
+# use pam_slurm_adopt to only allow access to users with job allocations
+  'add account pam_slurm_adopt.so to sshd':
+    arguments: ["action_generic_failure=deny", "action_adopt_failure=deny"]
+    control: "required"
+    ensure: "present"
+    module: "pam_slurm_adopt.so"
+    position: "after *[type=\"account\" and module=\"pam_localuser.so\"]"
+    service: "sshd"
+    type: "account"
+# remove pam_systemd, which is incompatible with pam_slurm_adopt
+  'remove pam_systemd.so from common-session':
+    ensure: "absent"
+    module: "pam_systemd.so"
+    service: "common-session"
+    type: "session"
+    require: "Class[Pam_access::Pam::Authselect]"  # not sure about SUSE but doesn't hurt
+profile_hostbased_ssh::pam_slurm_adopt::services_to_mask: []

--- a/manifests/pam_slurm_adopt.pp
+++ b/manifests/pam_slurm_adopt.pp
@@ -9,7 +9,7 @@
 #   https://bugs.schedmd.com/show_bug.cgi?id=3912
 #   https://bugs.schedmd.com/show_bug.cgi?id=5920
 #
-# @param pam_configs
+# @param pam_config
 #   Hash of data to pass to augeasproviders_pam.
 #
 # @param services_to_mask

--- a/manifests/shosts_equiv.pp
+++ b/manifests/shosts_equiv.pp
@@ -4,17 +4,22 @@
 # used in a standalone fashion (with proper Hiera data) but
 # intended to be used indirectly by including the target class.
 #
+# @param shosts_equiv_file
+#   Path to shosts.equiv file.
+#
 # @example
 #   include profile_hostbased_ssh::shosts_equiv
 class profile_hostbased_ssh::shosts_equiv (
   String $shosts_equiv_file,
 ) {
-  # ensure proper perms on shosts.equiv file
-  file { $shosts_equiv_file :
-    ensure  => file,
-    content => epp( 'profile_hostbased_ssh/shosts.equiv.epp' ),
-    group   => 'root',
-    mode    => '0644',
-    owner   => 'root',
+  if ! empty($profile_hostbased_ssh::known_hosts::hosts_data) {
+    # ensure proper perms on shosts.equiv file
+    file { $shosts_equiv_file :
+      ensure  => file,
+      content => epp( 'profile_hostbased_ssh/shosts.equiv.epp' ),
+      group   => 'root',
+      mode    => '0644',
+      owner   => 'root',
+    }
   }
 }


### PR DESCRIPTION
…ional.

Make managing ssh_known_hosts and shosts.equiv files Optional. Set the appropriate parameter(s) to undef/null to NOT manage one or both of these files:
   profile_hostbased_ssh::known_hosts:ssh_known_hosts_file
   profile_hostbased_ssh::shosts_equiv::shosts_equiv_file
This is helpful for scenarios with nodes that have multiple interfaces associated w/ the same hostname as this profile cannot currently build these two files for such hosts.

Add pam_slurm_adopt support for SUSE.
- /etc/pam.d/sshd is a bit different for SUSE as compared to RHEL.
- Also add pam_localuser.so to allow local users (e.g., qualys) as they generally won't be able to run jobs anyway. (Their access will still typically be gated by pam_access, etc., if configured.)

Regenerate REFERENCE.md.